### PR TITLE
set consent ui prensentation style to over fullscreen

### DIFF
--- a/Assets/ConsentManagementProvider/Plugins/iOS/Source/UnityController.m
+++ b/Assets/ConsentManagementProvider/Plugins/iOS/Source/UnityController.m
@@ -274,6 +274,7 @@
 - (void)onSPUIReady:(SPMessageViewController * _Nonnull)controller {
 //    NSLog(@"onSPUIReady");
     UIViewController *top = [UIApplication sharedApplication].keyWindow.rootViewController;
+    [controller setModalPresentationStyle:UIModalPresentationOverFullScreen];
     [top presentViewController: controller animated:YES completion: nil];
     UnitySendMessage([self getGOName], "OnConsentUIReady", "onSPUIReady from iOS!");
 }


### PR DESCRIPTION
The consent view controller should be presented over the entire screen, currently it's being presented as a modal. 

This PR addresses that. 