### PR TITLE
Fix Unity racing conditions 

### DIFF
--- a/Assets/ConsentManagementProvider/Scripts/observer/BroadcastEventDispatcher.cs
+++ b/Assets/ConsentManagementProvider/Scripts/observer/BroadcastEventDispatcher.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using ConsentManagementProviderLib.EventHandlerInterface;
 using UnityEngine.EventSystems;
 
@@ -7,7 +7,7 @@ namespace ConsentManagementProviderLib.Observer
 {
     internal static class BroadcastEventDispatcher
     {
-        public static Queue<Action> actions = new Queue<Action>();
+        public static ConcurrentQueue<Action> actions = new ConcurrentQueue<Action>();
 
         public static void Execute<T>(BaseEventData eventData, ExecuteEvents.EventFunction<T> functor) where T : IConsentEventHandler
         {

--- a/Assets/ConsentManagementProvider/Scripts/observer/BroadcastEventDispatcher.cs
+++ b/Assets/ConsentManagementProvider/Scripts/observer/BroadcastEventDispatcher.cs
@@ -19,5 +19,10 @@ namespace ConsentManagementProviderLib.Observer
                 actions.Enqueue(delegate { ExecuteEvents.Execute<T>(handler, eventData, functor); });
             }
         }
+
+        public static void Execute(Action action)
+        {
+            actions.Enqueue(action);
+        }
     }
 }

--- a/Assets/ConsentManagementProvider/Scripts/observer/BroadcastEventDispatcher.cs
+++ b/Assets/ConsentManagementProvider/Scripts/observer/BroadcastEventDispatcher.cs
@@ -13,7 +13,7 @@ namespace ConsentManagementProviderLib.Observer
         {
             var handlers = BroadcastReceivers.GetHandlersForEvent<T>();
             if (handlers == null) return;
-            CmpDebugUtil.Log($"{typeof(T).Name} has {handlers.Count} invokable instances");
+            CmpDebugUtil.Log($"{typeof(T).Name} has {handlers.Length} invokable instances");
             foreach (var handler in handlers)
             {
                 actions.Enqueue(delegate { ExecuteEvents.Execute<T>(handler, eventData, functor); });

--- a/Assets/ConsentManagementProvider/Scripts/observer/BroadcastEventsExecutor.cs
+++ b/Assets/ConsentManagementProvider/Scripts/observer/BroadcastEventsExecutor.cs
@@ -12,9 +12,9 @@ namespace ConsentManagementProviderLib.Observer
 
         private void Update()
         {
-            while (BroadcastEventDispatcher.actions.Count > 0)
+            while (BroadcastEventDispatcher.actions.TryDequeue(out var action))
             {
-                BroadcastEventDispatcher.actions.Dequeue()?.Invoke();
+                action?.Invoke();
             }
         }
     }

--- a/Assets/ConsentManagementProvider/Scripts/wrapper/Android/SpClientProxy.cs
+++ b/Assets/ConsentManagementProvider/Scripts/wrapper/Android/SpClientProxy.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using ConsentManagementProviderLib.Json;
+using ConsentManagementProviderLib.Observer;
 using UnityEngine;
 
 namespace ConsentManagementProviderLib.Android
@@ -58,16 +59,20 @@ namespace ConsentManagementProviderLib.Android
         void onConsentReady(string spConsents) 
         {
             CmpDebugUtil.Log("I've reached the C# onConsentReady with json string: " + spConsents);
-            try
+
+            BroadcastEventDispatcher.Execute(() =>
             {
-                SpConsents consents = JsonUnwrapper.UnwrapSpConsentsAndroid(spConsents);
-                _spConsents = consents;
-                ConsentMessenger.Broadcast<IOnConsentReady>(consents);
-            }
-            catch (Exception e)
-            {
-                ConsentMessenger.Broadcast<IOnConsentError>(e);
-            }
+                try
+                {
+                    SpConsents consents = JsonUnwrapper.UnwrapSpConsentsAndroid(spConsents);
+                    _spConsents = consents;
+                    ConsentMessenger.Broadcast<IOnConsentReady>(consents);
+                }
+                catch (Exception e)
+                {
+                    ConsentMessenger.Broadcast<IOnConsentError>(e);
+                }
+            });
         }
         
         /**
@@ -78,16 +83,20 @@ namespace ConsentManagementProviderLib.Android
             CmpDebugUtil.ForceEnableNextCmpLog();
             CmpDebugUtil.LogWarning($"I've reached the C# onSpFinished with JSON spConsents={spConsents}");
             Console.WriteLine($"spConsents= `{spConsents}");
-            try
+
+            BroadcastEventDispatcher.Execute(() =>
             {
-                SpConsents consents = JsonUnwrapper.UnwrapSpConsentsAndroid(spConsents);
-                _spConsents = consents;
-                ConsentMessenger.Broadcast<IOnConsentSpFinished>(consents);
-            }
-            catch (Exception e)
-            {
-                ConsentMessenger.Broadcast<IOnConsentError>(e);
-            }
+                try
+                {
+                    SpConsents consents = JsonUnwrapper.UnwrapSpConsentsAndroid(spConsents);
+                    _spConsents = consents;
+                    ConsentMessenger.Broadcast<IOnConsentSpFinished>(consents);
+                }
+                catch (Exception e)
+                {
+                    ConsentMessenger.Broadcast<IOnConsentError>(e);
+                }
+            });
         }
 
         void onError(AndroidJavaObject rawThrowableObject)


### PR DESCRIPTION
This fix mitigates native android crashes caused by racing conditions withing Unity IL2CPP type system due to concurrent JSON deserialization.

Similar issue was fixed by Unity here: https://issuetracker.unity3d.com/issues/il2cpp-crash-in-il2cpp-vm-class-setupmethods-when-equalitycomparer-is-created-from-multiple-threads